### PR TITLE
Some fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,32 +8,21 @@ on: [pull_request, push]
 
 jobs:
   build:
-    strategy:
-      matrix:
-        # Use these Java versions
-        java: [
-          17,    # Current Java LTS & minimum supported by Minecraft
-        ]
-        # and run on both Linux and Windows
-        os: [ubuntu-20.04, windows-2022]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: checkout repository
-        uses: actions/checkout@v2
-      - name: validate gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
-      - name: setup jdk ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/checkout@v4
+      - name: setup jdk 17
+        uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.java }}
-      - name: make gradle wrapper executable
-        if: ${{ runner.os != 'Windows' }}
-        run: chmod +x ./gradlew
+          java-version: '17'
+          distribution: 'temurin'
+      - name: setup gradle
+        uses: gradle/actions/setup-gradle@v3
       - name: build
         run: ./gradlew build
       - name: capture build artifacts
-        if: ${{ runner.os == 'Linux' && matrix.java == '17' }} # Only upload artifacts built from latest java on one OS
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4.3.3
         with:
           name: Artifacts
           path: build/libs/

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'fabric-loom' version '1.7.bta'
+	id 'com.gradleup.shadow' version '8.3.5'
 	id 'java'
 }
 
@@ -96,9 +97,7 @@ dependencies {
 
 	implementation "com.github.electronstudio:sdl2gdx:1.0.3"
 	//includeInJar "com.github.electronstudio:sdl2gdx:1.0.3"
-	implementation "net.dv8tion:JDA:5.0.0-beta.13"
 	//includeInJar "net.dv8tion:JDA:5.0.0-beta.13"
-	implementation "club.minnced:discord-webhooks:0.8.4"
 /*	includeInJar "club.minnced:discord-webhooks:0.8.4"
 	includeInJar "com.google.code.gson:gson:2.8.9"*/
 
@@ -112,7 +111,8 @@ dependencies {
 	implementation("org.apache.logging.log4j:log4j-api:${log4jVersion}")
 	implementation("org.apache.logging.log4j:log4j-1.2-api:${log4jVersion}")
 
-	include(implementation("org.apache.commons:commons-lang3:3.12.0"))
+	implementation shadow("net.dv8tion:JDA:5.2.2")
+	implementation shadow("club.minnced:discord-webhooks:0.8.4")
 
 	modImplementation("com.github.zarzelcow:legacy-lwjgl3:1.0.4")
 	implementation platform("org.lwjgl:lwjgl-bom:$lwjglVersion")
@@ -145,6 +145,26 @@ jar {
 	from("LICENSE") {
 		rename { "${it}_${archivesBaseName}" }
 	}
+}
+
+remapJar {
+	dependsOn(shadowJar)
+	mustRunAfter(shadowJar)
+	inputFile = file(shadowJar.archivePath)
+}
+
+shadowJar {
+    configurations = [project.configurations.shadow]
+    exclude("META-INF")
+    //taken from https://github.com/discord-jda/JDA/blob/master/build.gradle.kts
+    exclude("natives/**")
+    exclude("com/sun/jna/**")
+    exclude("com/google/crypto/tink/**")
+    exclude("com/google/gson/**")
+    exclude("com/google/protobuf/**")
+    exclude("google/protobuf/**")
+    exclude("club/minnced/opus/util/*")
+    exclude("tomp2p/opuswrapper/*")
 }
 
 configurations.configureEach {

--- a/src/main/java/de/olivermakesco/bta_discord_integration/server/DiscordClient.java
+++ b/src/main/java/de/olivermakesco/bta_discord_integration/server/DiscordClient.java
@@ -39,7 +39,7 @@ public class DiscordClient {
 
             return true;
         } catch (Throwable t) {
-            de.olivermakesco.bta_discord_integration.BTADiscordIntegrationMod.LOGGER.debug("Unable to start discord bot.", t);
+            de.olivermakesco.bta_discord_integration.BTADiscordIntegrationMod.LOGGER.error("Unable to start discord bot.", t);
             return false;
         }
     }


### PR DESCRIPTION
Makes built artifacts once again contain libraries required for JDA.

Also fixes GitHub actions workflow because it used discontinued actions.

Made the error on load actually print the error without having to change Log4J settings to make it easier to know what went wrong.